### PR TITLE
Add GitlabAuth & ForgejoAuth providers & make tokens storage modular

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ requires-python = ">=3.9"
 dependencies = [
     "requests-oauthlib",
     "platformdirs",
+    "keyring",
 ]
 classifiers = [
     "Programming Language :: Python :: 3",

--- a/src/oauthcli/flow.py
+++ b/src/oauthcli/flow.py
@@ -12,6 +12,7 @@ import webbrowser
 import string
 import wsgiref.simple_server
 import wsgiref.util
+import os
 import os.path
 import sys
 from base64 import urlsafe_b64encode
@@ -303,9 +304,8 @@ class AuthFlow:
         local_server.timeout = timeout_seconds
         local_server.handle_request()
 
-        # Note: using https here because oauthlib is very picky that
-        # OAuth 2.0 should only occur over https.
-        authorization_response = wsgi_app.last_request_uri.replace("http", "https")
+        # OAuth 2.0 should only occur over https, disable oauthlib security
+        os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "true"
         self.fetch_token(
             authorization_response=authorization_response, audience=token_audience
         )

--- a/src/oauthcli/flow.py
+++ b/src/oauthcli/flow.py
@@ -6,8 +6,6 @@ import contextlib
 import socket
 import hashlib
 import logging
-import platformdirs
-import json
 import webbrowser
 import string
 import wsgiref.simple_server
@@ -19,6 +17,8 @@ from base64 import urlsafe_b64encode
 from requests_oauthlib import OAuth2Session
 from typing import Optional, Union, Callable
 
+from .storage import BaseStorage, ConfigFileStorage
+
 
 class AuthFlow:
     def __init__(
@@ -28,6 +28,7 @@ class AuthFlow:
         auth_url: str,
         token_url: str,
         client_secret: Optional[str] = None,
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         self.provider_id = provider_id
         self.session = session
@@ -37,6 +38,8 @@ class AuthFlow:
         self.token_url = token_url
         self.client_secret = client_secret
         self.default_local_host = 'localhost'
+        self.tokens_storage = tokens_storage if tokens_storage else ConfigFileStorage()
+        assert isinstance(self.tokens_storage, BaseStorage), "Invalid tokens storage provided"
         self._load_token()
 
     @property
@@ -77,40 +80,15 @@ class AuthFlow:
         return self.session.options(self.process_url(api), **kwargs)
 
     def _load_token(self):
-        if not self.session.client_id:
-            return
-        token_key = f'{self.provider_id}/{self.session.client_id}'
-        config_dir = platformdirs.user_config_dir('PythonCliAuth', ensure_exists=True)
-        filename = os.path.join(config_dir, 'tokens.json')
-        if os.path.exists(filename):
-            with open(filename, 'r') as f:
-                tokens = json.load(f)
-                if token_key in tokens:
-                    self.session.token = tokens[token_key]
+        if self.session.client_id:
+            token = self.tokens_storage.get_token(
+                self.provider_id, self.session.client_id
+            )
+            if token:
+                self.session.token = token
 
     def _save_token(self, token: Optional[dict]):
-        token_key = f'{self.provider_id}/{self.session.client_id}'
-        config_dir = platformdirs.user_config_dir('PythonCliAuth', ensure_exists=True)
-        filename = os.path.join(config_dir, 'tokens.json')
-        tokens = {}
-        try:
-            if os.path.exists(filename):
-                with open(filename, 'r') as f:
-                    tokens = json.load(f)
-        except IOError:
-            pass
-
-        if not token:
-            if token_key in tokens:
-                del tokens[token_key]
-        else:
-            tokens[token_key] = token
-
-        try:
-            with open(filename, 'w') as f:
-                json.dump(tokens, f)
-        except IOError:
-            logging.exception('Could not save tokens to %s', filename)
+        self.tokens_storage.set_token(self.provider_id, self.session.client_id, token)
 
     def authorization_url(self, **kwargs):
         # ↓ this is google-specific

--- a/src/oauthcli/flow.py
+++ b/src/oauthcli/flow.py
@@ -285,7 +285,7 @@ class AuthFlow:
         # OAuth 2.0 should only occur over https, disable oauthlib security
         os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "true"
         self.fetch_token(
-            authorization_response=authorization_response, audience=token_audience
+            authorization_response=wsgi_app.last_request_uri, audience=token_audience
         )
 
         # This closes the socket

--- a/src/oauthcli/flow.py
+++ b/src/oauthcli/flow.py
@@ -169,6 +169,7 @@ class AuthFlow:
         token_audience=None,
         force: bool = False,
         token_test: Optional[Callable] = None,
+        redirect_uri: Optional[Callable] = None,
         **kwargs
     ):
         """Runs auth flow without starting a web server.
@@ -177,7 +178,7 @@ class AuthFlow:
         if self._check_auth(force, token_test):
             return self
 
-        self.session.redirect_uri = 'urn:ietf:wg:oauth:2.0:oob'
+        self.session.redirect_uri = redirect_uri if redirect_uri else 'urn:ietf:wg:oauth:2.0:oob'
         auth_url, _ = self.authorization_url(**kwargs)
 
         if open_browser:

--- a/src/oauthcli/flow.py
+++ b/src/oauthcli/flow.py
@@ -10,7 +10,6 @@ import webbrowser
 import string
 import wsgiref.simple_server
 import wsgiref.util
-import os
 import os.path
 import sys
 from base64 import urlsafe_b64encode
@@ -282,8 +281,9 @@ class AuthFlow:
         local_server.timeout = timeout_seconds
         local_server.handle_request()
 
-        # OAuth 2.0 should only occur over https, disable oauthlib security
-        os.environ['OAUTHLIB_INSECURE_TRANSPORT'] = "true"
+        # Note: using https here because oauthlib is very picky that
+        # OAuth 2.0 should only occur over https.
+        authorization_response = wsgi_app.last_request_uri.replace("http", "https")
         self.fetch_token(
             authorization_response=wsgi_app.last_request_uri, audience=token_audience
         )

--- a/src/oauthcli/providers.py
+++ b/src/oauthcli/providers.py
@@ -183,3 +183,24 @@ class LinkedInAuth(AuthFlow):
             client_secret,
             storage=storage,
         )
+
+
+class ForgejoAuth(AuthFlow):
+    def __init__(
+        self,
+        server,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[Sequence[str]] = None,
+        provider_id: str = 'forgejo',
+        storage: Optional[BaseStorage] = None,
+    ):
+        super().__init__(
+            provider_id,
+            OAuth2Session(client_id, scope=scopes),
+            f'{server.rstrip("/")}/login/oauth/authorize',
+            f'{server.rstrip("/")}/login/oauth/access_token',
+            client_secret,
+            storage=storage,
+        )
+        self.server = server.rstrip("/")

--- a/src/oauthcli/providers.py
+++ b/src/oauthcli/providers.py
@@ -12,7 +12,7 @@ class OpenStreetMapAuth(AuthFlow):
         scopes: Sequence[str],
         provider_id: str = 'openstreetmap',
         url: str = 'https://www.openstreetmap.org',
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             provider_id,
@@ -20,7 +20,7 @@ class OpenStreetMapAuth(AuthFlow):
             f'{url.rstrip("/")}/oauth2/authorize',
             f'{url.rstrip("/")}/oauth2/token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
         self.default_local_host = '127.0.0.1'
         self.url = url.rstrip("/")
@@ -35,13 +35,13 @@ class OpenStreetMapDevAuth(OpenStreetMapAuth):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             client_id, client_secret, scopes,
             'openstreetmap_dev',
             'https://api06.dev.openstreetmap.org',
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
 
 
@@ -51,7 +51,7 @@ class GoogleAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'google',
@@ -59,7 +59,7 @@ class GoogleAuth(AuthFlow):
             'https://accounts.google.com/o/oauth2/auth',
             'https://oauth2.googleapis.com/token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
 
 
@@ -69,7 +69,7 @@ class GitHubAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Optional[Sequence[str]] = None,
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'github',
@@ -77,7 +77,7 @@ class GitHubAuth(AuthFlow):
             'https://github.com/login/oauth/authorize',
             'https://github.com/login/oauth/access_token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
 
     def process_url(self, api: str) -> str:
@@ -92,7 +92,7 @@ class GitlabAuth(AuthFlow):
         scopes: Optional[Sequence[str]] = None,
         provider_id: str = 'gitlab',
         url: str = 'https://gitlab.com',
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             provider_id,
@@ -100,7 +100,7 @@ class GitlabAuth(AuthFlow):
             f'{url.rstrip("/")}/oauth/authorize',
             f'{url.rstrip("/")}/oauth/token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
         self.url = url.rstrip("/")
 
@@ -112,7 +112,7 @@ class MastodonAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Optional[Sequence[str]] = None,
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'mastodon',
@@ -120,7 +120,7 @@ class MastodonAuth(AuthFlow):
             f'{server.rstrip("/")}/oauth2/authorize',
             f'{server.rstrip("/")}/oauth2/token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
         self.server = server.rstrip('/')
 
@@ -134,7 +134,7 @@ class RedditAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'reddit',
@@ -142,7 +142,7 @@ class RedditAuth(AuthFlow):
             'https://www.reddit.com/oauth2/authorize',
             'https://www.reddit.com/oauth2/access_token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
 
     def process_url(self, api: str) -> str:
@@ -155,7 +155,7 @@ class FacebookAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'facebook',
@@ -163,7 +163,7 @@ class FacebookAuth(AuthFlow):
             'https://www.facebook.com/dialog/oauth',
             'https://graph.facebook.com/oauth/access_token',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )
 
 
@@ -173,7 +173,7 @@ class LinkedInAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
-        tokens_storage: Optional[BaseStorage] = None,
+        storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'linkedin',
@@ -181,5 +181,5 @@ class LinkedInAuth(AuthFlow):
             'https://www.linkedin.com/uas/oauth2/authorization',
             'https://www.linkedin.com/uas/oauth2/accessToken',
             client_secret,
-            tokens_storage=tokens_storage,
+            storage=storage,
         )

--- a/src/oauthcli/providers.py
+++ b/src/oauthcli/providers.py
@@ -1,4 +1,5 @@
 from .flow import AuthFlow
+from .storage import BaseStorage
 from requests_oauthlib import OAuth2Session
 from typing import Optional, Sequence
 
@@ -11,6 +12,7 @@ class OpenStreetMapAuth(AuthFlow):
         scopes: Sequence[str],
         provider_id: str = 'openstreetmap',
         url: str = 'https://www.openstreetmap.org',
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             provider_id,
@@ -18,6 +20,7 @@ class OpenStreetMapAuth(AuthFlow):
             f'{url.rstrip("/")}/oauth2/authorize',
             f'{url.rstrip("/")}/oauth2/token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
         self.default_local_host = '127.0.0.1'
         self.url = url.rstrip("/")
@@ -32,11 +35,13 @@ class OpenStreetMapDevAuth(OpenStreetMapAuth):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             client_id, client_secret, scopes,
             'openstreetmap_dev',
-            'https://api06.dev.openstreetmap.org'
+            'https://api06.dev.openstreetmap.org',
+            tokens_storage=tokens_storage,
         )
 
 
@@ -46,6 +51,7 @@ class GoogleAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'google',
@@ -53,6 +59,7 @@ class GoogleAuth(AuthFlow):
             'https://accounts.google.com/o/oauth2/auth',
             'https://oauth2.googleapis.com/token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
 
 
@@ -62,6 +69,7 @@ class GitHubAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Optional[Sequence[str]] = None,
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'github',
@@ -69,6 +77,7 @@ class GitHubAuth(AuthFlow):
             'https://github.com/login/oauth/authorize',
             'https://github.com/login/oauth/access_token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
 
     def process_url(self, api: str) -> str:
@@ -83,6 +92,7 @@ class GitlabAuth(AuthFlow):
         scopes: Optional[Sequence[str]] = None,
         provider_id: str = 'gitlab',
         url: str = 'https://gitlab.com',
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             provider_id,
@@ -90,6 +100,7 @@ class GitlabAuth(AuthFlow):
             f'{url.rstrip("/")}/oauth/authorize',
             f'{url.rstrip("/")}/oauth/token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
         self.url = url.rstrip("/")
 
@@ -101,6 +112,7 @@ class MastodonAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Optional[Sequence[str]] = None,
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'mastodon',
@@ -108,6 +120,7 @@ class MastodonAuth(AuthFlow):
             f'{server.rstrip("/")}/oauth2/authorize',
             f'{server.rstrip("/")}/oauth2/token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
         self.server = server.rstrip('/')
 
@@ -121,6 +134,7 @@ class RedditAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'reddit',
@@ -128,6 +142,7 @@ class RedditAuth(AuthFlow):
             'https://www.reddit.com/oauth2/authorize',
             'https://www.reddit.com/oauth2/access_token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
 
     def process_url(self, api: str) -> str:
@@ -140,6 +155,7 @@ class FacebookAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'facebook',
@@ -147,6 +163,7 @@ class FacebookAuth(AuthFlow):
             'https://www.facebook.com/dialog/oauth',
             'https://graph.facebook.com/oauth/access_token',
             client_secret,
+            tokens_storage=tokens_storage,
         )
 
 
@@ -156,6 +173,7 @@ class LinkedInAuth(AuthFlow):
         client_id: str,
         client_secret: str,
         scopes: Sequence[str],
+        tokens_storage: Optional[BaseStorage] = None,
     ):
         super().__init__(
             'linkedin',
@@ -163,4 +181,5 @@ class LinkedInAuth(AuthFlow):
             'https://www.linkedin.com/uas/oauth2/authorization',
             'https://www.linkedin.com/uas/oauth2/accessToken',
             client_secret,
+            tokens_storage=tokens_storage,
         )

--- a/src/oauthcli/providers.py
+++ b/src/oauthcli/providers.py
@@ -75,6 +75,25 @@ class GitHubAuth(AuthFlow):
         return f'https://api.github.com/{api.lstrip("/")}'
 
 
+class GitlabAuth(AuthFlow):
+    def __init__(
+        self,
+        client_id: str,
+        client_secret: str,
+        scopes: Optional[Sequence[str]] = None,
+        provider_id: str = 'gitlab',
+        url: str = 'https://gitlab.com',
+    ):
+        super().__init__(
+            provider_id,
+            OAuth2Session(client_id, scope=scopes),
+            f'{url.rstrip("/")}/oauth/authorize',
+            f'{url.rstrip("/")}/oauth/token',
+            client_secret,
+        )
+        self.url = url.rstrip("/")
+
+
 class MastodonAuth(AuthFlow):
     def __init__(
         self,

--- a/src/oauthcli/storage.py
+++ b/src/oauthcli/storage.py
@@ -1,0 +1,94 @@
+"""Tokens storage"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+import keyring
+import platformdirs
+
+log = logging.getLogger(__name__)
+
+
+class BaseStorage:
+
+    @staticmethod
+    def _token_key(provider_id: str, client_id: str):
+        return f'{provider_id}/{client_id}'
+
+    def load(self):
+        raise NotImplementedError()
+
+    def save(self, tokens: dict):
+        raise NotImplementedError()
+
+    def get_token(self, provider_id: str, client_id: str):
+        return self.load().get(self._token_key(provider_id, client_id))
+
+    def set_token(self, provider_id: str, client_id: str, token: Optional[dict]):
+        token_key = self._token_key(provider_id, client_id)
+        tokens = self.load()
+
+        if not token:
+            if token_key in tokens:
+                del tokens[token_key]
+        else:
+            tokens[token_key] = token
+        self.save(tokens)
+
+
+class ConfigFileStorage(BaseStorage):
+
+    def __init__(self, path: Optional[str] = None, config_name=None):
+        self.path = (
+            path if path
+            else os.path.join(
+                platformdirs.user_config_dir(config_name if config_name else 'PythonCliAuth', ensure_exists=True),
+                'tokens.json'
+            )
+        )
+
+    def load(self):
+        log.debug("Load tokens from %s", self.path)
+        if not os.path.exists(self.path):
+            log.debug("Tokens file %s doest not exists", self.path)
+            return {}
+        with open(self.path, 'r') as f:
+            return json.load(f)
+
+    def save(self, tokens: dict):
+        log.debug("Save tokens to %s", self.path)
+        try:
+            with open(self.path, 'w') as f:
+                json.dump(tokens, f)
+        except IOError:
+            log.exception('Error saving tokens to %s', self.path)
+
+
+class KeyringStorage(BaseStorage):
+
+    def __init__(self, service_name: Optional[str] = None):
+        self.service_name = service_name if service_name else 'python-cli-oauth2'
+
+    def get_token(self, provider_id: str, client_id: str):
+        log.debug("Get token for %s@%s from keyring", client_id, provider_id)
+        raw_token = keyring.get_password(self.service_name, self._token_key(provider_id, client_id))
+        return json.loads(raw_token) if raw_token else None
+
+    def set_token(self, provider_id: str, client_id: str, token: Optional[dict]):
+        log.debug("Save token for %s@%s to keyring", client_id, provider_id)
+        keyring.set_password(
+            self.service_name,
+            self._token_key(provider_id, client_id),
+            json.dumps(token)
+        )
+
+
+class NoneStorage(BaseStorage):
+
+    def load(self):
+        return {}
+
+    def save(self, tokens: dict):
+        pass

--- a/src/oauthcli/storage.py
+++ b/src/oauthcli/storage.py
@@ -42,9 +42,9 @@ class ConfigFileStorage(BaseStorage):
 
     def __init__(self, path: Optional[str] = None, config_name=None):
         self.path = (
-            path if path
-            else os.path.join(
-                platformdirs.user_config_dir(config_name if config_name else 'PythonCliAuth', ensure_exists=True),
+            path
+            or os.path.join(
+                platformdirs.user_config_dir(config_name or 'PythonCliAuth', ensure_exists=True),
                 'tokens.json'
             )
         )


### PR DESCRIPTION
Hello,

In a new project, I need to handle Gitlab OAuth2 from CLI and I was happy to find your lib. I add support for Gitlab that [does not support](https://gitlab.com/gitlab-org/gitlab/-/issues/15287) `urn:ietf:wg:oauth:2.0:oob` redirect URI so I also add a `redirect_uri` parameter to `AuthFlow.auth_code()`.

Furthermore, I don't want to store tokens in my case and I think it's could be great to have possibilty to store tokens in a more secure way. So, I create a modular way to store token: I keep your method as default and adding two new storage backends:
  * `NoneStorage`: disable storage
  * `KeryingStorage`: use [keyring](https://pypi.org/project/keyring/) lib to store token

To use one of them, we just have to provide one instance of them by using the `tokens_storage` parameter of the provider:

```python
auth = GitlabAuth(
    client_id,
    secret_id,
    ['read_user'],
    url=server_url,
    tokens_storage=KeyringStorage() ,
)
```

The storage backend constructor allow to customize their behaviour, so I add some parameters:
* a `path` parameter to `ConfigFileStorage` to change the default storage path (`~/.config/PythonCliAuth/tokens.json`)
* a `service_name` parameter to `KeyringStorage` to change the default service name (`python-cli-oauth2`)

__Edit:__ I also added [Forgejo](https://forgejo.org/) auth provider too. It may be also compatible with [Gitea](https://about.gitea.com/).